### PR TITLE
fix compile error

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,2 +1,0 @@
-gom "github.com/r7kamura/gospel"
-

--- a/hoedown.go
+++ b/hoedown.go
@@ -1,6 +1,6 @@
 package hoedown
 
-// #cgo CFLAGS: -c -g -O3 -Wall -Wextra -Wno-unused-parameter
+// #cgo CFLAGS: -g -O3 -Wall -Wextra -Wno-unused-parameter
 // #include "markdown.h"
 // #include "html.h"
 import "C"


### PR DESCRIPTION
broken after go 1.8.7.
```
go build github.com/kentaro/go-hoedown: invalid flag in #cgo CFLAGS: -c
```

see: https://github.com/golang/go/wiki/InvalidFlag