### PR TITLE
no symlinks to supports go.mod

### DIFF
--- a/autolink.c
+++ b/autolink.c
@@ -1,1 +1,0 @@
-hoedown/src/autolink.c

--- a/autolink.h
+++ b/autolink.h
@@ -1,1 +1,0 @@
-hoedown/src/autolink.h

--- a/buffer.c
+++ b/buffer.c
@@ -1,1 +1,0 @@
-hoedown/src/buffer.c

--- a/buffer.h
+++ b/buffer.h
@@ -1,1 +1,0 @@
-hoedown/src/buffer.h

--- a/escape.c
+++ b/escape.c
@@ -1,1 +1,0 @@
-hoedown/src/escape.c

--- a/escape.h
+++ b/escape.h
@@ -1,1 +1,0 @@
-hoedown/src/escape.h

--- a/hoedown.go
+++ b/hoedown.go
@@ -1,8 +1,16 @@
 package hoedown
 
-// #cgo CFLAGS: -g -O3 -Wall -Wextra -Wno-unused-parameter
+// #cgo CFLAGS: -g -O3 -Wall -Wextra -Wno-unused-parameter -I${SRCDIR}/hoedown/src
 // #include "markdown.h"
 // #include "html.h"
+// #include "autolink.c"
+// #include "buffer.c"
+// #include "escape.c"
+// #include "html.c"
+// #include "html_blocks.c"
+// #include "html_smartypants.c"
+// #include "markdown.c"
+// #include "stack.c"
 import "C"
 
 import (

--- a/html.c
+++ b/html.c
@@ -1,1 +1,0 @@
-hoedown/src/html.c

--- a/html.h
+++ b/html.h
@@ -1,1 +1,0 @@
-hoedown/src/html.h

--- a/html_blocks.c
+++ b/html_blocks.c
@@ -1,1 +1,0 @@
-hoedown/src/html_blocks.c

--- a/html_smartypants.c
+++ b/html_smartypants.c
@@ -1,1 +1,0 @@
-hoedown/src/html_smartypants.c

--- a/markdown.c
+++ b/markdown.c
@@ -1,1 +1,0 @@
-hoedown/src/markdown.c

--- a/markdown.h
+++ b/markdown.h
@@ -1,1 +1,0 @@
-hoedown/src/markdown.h

--- a/stack.c
+++ b/stack.c
@@ -1,1 +1,0 @@
-hoedown/src/stack.c

--- a/stack.h
+++ b/stack.h
@@ -1,1 +1,0 @@
-hoedown/src/stack.h


### PR DESCRIPTION
Use `#include` instead of symlinks.
actually `go mod` doesn't support symlinks. and also it in future. (maybe)
see also:  https://github.com/golang/go/issues/24057#issuecomment-377430635